### PR TITLE
notes-app UI glitches removal and functionality improvement

### DIFF
--- a/clickable.json
+++ b/clickable.json
@@ -1,0 +1,4 @@
+{
+  "template": "cmake",
+  "kill": "qmlscene"
+}

--- a/src/app/qml/components/NoteHeader.qml
+++ b/src/app/qml/components/NoteHeader.qml
@@ -17,6 +17,7 @@ FocusScope {
 
     property alias title: titleTextField.text
 
+    signal titleEntered();
     signal editReminders();
     signal editTags();
     Notebooks {
@@ -54,6 +55,9 @@ FocusScope {
             visible: root.editingEnabled
             style: TextFieldStyle {
                 background: null
+            }
+            onAccepted : {
+                titleEntered();
             }
         }
 

--- a/src/app/qml/ui/EditNoteView.qml
+++ b/src/app/qml/ui/EditNoteView.qml
@@ -61,6 +61,7 @@ Item {
     }
 
     function init() {
+
         if (root.isBottomEdge) {
             return;
         }
@@ -69,10 +70,14 @@ Item {
             header.title = "";
             header.forceActiveFocus();
         } else {
-            noteTextArea.forceActiveFocus();
+            setFocusTimer.start();
         }
     }
 
+    function focusTextArea() {
+        noteTextArea.cursorPosition = noteTextArea.length - 1;
+        noteTextArea.forceActiveFocus();
+    }
 
     QtObject {
         id: priv
@@ -158,6 +163,10 @@ Item {
                         note: root.note
                         focus: root.newNote
 
+                        onTitleEntered: {
+                            focusTextArea();
+                        }
+
                         onEditReminders: {
                             pageStack.push(Qt.resolvedUrl("SetReminderPage.qml"), { note: root.note});
                         }
@@ -173,7 +182,7 @@ Item {
 //                         height: Math.max(flick.height - header.height, paintedHeight + units.gu(2))
                          autoSize: true
                          maximumLineCount: 0
-                         focus: true
+                         focus: !root.newnote
                          wrapMode: TextEdit.Wrap
                          textFormat: TextEdit.RichText
                          text: root.note ? root.note.richTextContent : ""
@@ -196,11 +205,10 @@ Item {
                          // in order to have any effect.
                          Timer {
                              id: setFocusTimer
-                             interval: 1
+                             interval: 300
                              repeat: false
                              onTriggered: {
-                                 noteTextArea.cursorPosition = noteTextArea.length;
-                                 noteTextArea.forceActiveFocus();
+                                 focusTextArea();
                              }
                          }
                      }

--- a/src/app/qml/ui/NotebooksPage.qml
+++ b/src/app/qml/ui/NotebooksPage.qml
@@ -70,7 +70,7 @@ Page {
         states: [
             State {
                 name: "newNotebook"; when: contentColumn.newNotebook
-                PropertyChanges { target: newNotebookContainer; opacity: 1; height: newNotebookContainer.implicitHeight }
+                PropertyChanges { target: newNotebookContainer; opacity: 1; height: newNotebookContainer.implicitHeight; enabled: true }
                 PropertyChanges { target: buttonRow; opacity: 1; height: cancelButton.height + units.gu(4) }
             }
         ]
@@ -81,6 +81,7 @@ Page {
             visible: opacity > 0
             opacity: 0
             clip: true
+            enabled: false
 
             Behavior on height {
                 UbuntuNumberAnimation {}
@@ -97,6 +98,14 @@ Page {
                 id: newNoteTitleTextField
                 objectName: "newNoteTitleTextField"
                 anchors { left: parent.left; right: parent.right; margins: units.gu(2); verticalCenter: parent.verticalCenter }
+                onAccepted: {
+                    if(newNoteTitleTextField.length > 0 || newNoteTitleTextField.inputMethodComposing) {
+                        NotesStore.createNotebook(newNoteTitleTextField.displayText);
+                        newNoteTitleTextField.text = "";
+                        contentColumn.newNotebook = false
+                        newNoteTitleTextField.focus = false;
+                    }
+                }
             }
         }
 

--- a/src/app/qml/ui/SearchNotesPage.qml
+++ b/src/app/qml/ui/SearchNotesPage.qml
@@ -31,6 +31,10 @@ Page {
 
     title: i18n.tr("Search notes")
 
+    onActiveChanged: {
+        searchField.forceActiveFocus();
+    }
+
     Column {
         anchors { fill: parent; topMargin: units.gu(2); bottomMargin: units.gu(2) }
         spacing: units.gu(2)
@@ -43,6 +47,7 @@ Page {
                 id: searchField
                 width: parent.width - searchButton.width - parent.spacing
                 anchors.verticalCenter: parent.verticalCenter
+                focus: true
 
                 primaryItem: Icon {
                     height: searchField.height - units.gu(1)


### PR DESCRIPTION
Hello Maintainers,

I have made some improvements to notes-app mostly in UI area and some in functionality area. I have come across few bugs and glitches while using notes on my Nexus 4.

**List of bugs & glitches removed**

- If existing note is opened for editing then cursor appears at the start of the body text instead of the end.

- Keyboard pops up when one touches anywhere in "Notebooks" page is selected. It also opens up when any Notebook is selected from the page.

**List of functionality improvements**

- Now one can jump directly from note title to body textarea when enter is pressed.

- Keyboard opens up automatically when search is pressed.

- Apart from the save button, now one can immediately create notebook by pressing enter on title bar while creating notebook. 

Regards,
Nisarg Patel

