### PR TITLE
solve invisible icon in portrait mode when editing a note

### DIFF
--- a/clickable.json
+++ b/clickable.json
@@ -1,7 +1,6 @@
 {
   "template": "cmake",
   "kill": "qmlscene",
-  "sdk": "ubuntu-sdk-16.04",
   "dependencies": [
     "libssl-dev",
     "libboost-dev"

--- a/manifest.json.in
+++ b/manifest.json.in
@@ -23,7 +23,7 @@
     "maintainer": "UBports <dev@ubports.com>",
     "name": "com.ubuntu.reminders",
     "title": "Notes",
-    "version": "0.6.3",
+    "version": "0.6.4",
     "x-test": {
         "autopilot": {
             "autopilot_module": "@AUTOPILOT_DIR@",

--- a/po/de.po
+++ b/po/de.po
@@ -8,14 +8,15 @@ msgstr ""
 "Project-Id-Version: reminders-app\n"
 "Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
 "POT-Creation-Date: 2016-05-28 22:28+0200\n"
-"PO-Revision-Date: 2016-07-04 14:49+0000\n"
-"Last-Translator: Tobias Bannert <tobannert@gmail.com>\n"
+"PO-Revision-Date: 2018-11-05 20:50+0100\n"
+"Last-Translator: Daniel Frost <one@frostinfo.de>\n"
 "Language-Team: German <de@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2017-04-05 07:24+0000\n"
-"X-Generator: Launchpad (build 18335)\n"
+"X-Generator: Poedit 2.0.6\n"
+"Language: de\n"
 
 #: com.ubuntu.reminders.desktop.in.in.h:1 src/app/qml/Reminders.qml:559
 msgid "Notes"
@@ -73,16 +74,14 @@ msgid "Sync with Evernote"
 msgstr "Synchronisieren mit Evernote"
 
 #: src/app/qml/Reminders.qml:714
-msgid ""
-"Notes can be stored on this device, or optionally synced with Evernote."
+msgid "Notes can be stored on this device, or optionally synced with Evernote."
 msgstr ""
 "Ihre Notizen können Sie auf diesem Gerät speichern oder mit Evernote "
 "synchronisieren."
 
 #: src/app/qml/Reminders.qml:715
 msgid "To sync with Evernote, you need an Evernote account."
-msgstr ""
-"Um mit Evernote zu synchronisieren benötigen Sie einen Evernote-Konto."
+msgstr "Um mit Evernote zu synchronisieren benötigen Sie einen Evernote-Konto."
 
 #: src/app/qml/Reminders.qml:730
 msgid "Not Now"
@@ -146,8 +145,7 @@ msgid "Enter a tag name to attach it to the note."
 msgstr "Bitte einen Schlagwortnamen eingeben, um ihn einer Notiz zuzuordnen."
 
 #: src/app/qml/components/EditTagsDialog.qml:33
-msgid ""
-"Enter a tag name or select one from the list to attach it to the note."
+msgid "Enter a tag name or select one from the list to attach it to the note."
 msgstr ""
 "Bitte einen Schlagwortnamen eingeben oder einen von der Liste auswähle, um "
 "ihn einer Notiz zuzuordnen."
@@ -166,7 +164,7 @@ msgstr "OK"
 #: src/app/qml/components/EditTagsDialog.qml:202
 #: src/app/qml/ui/EditNoteView.qml:604 src/app/qml/ui/NoteView.qml:150
 msgid "Close"
-msgstr "Fertig"
+msgstr "Schließen"
 
 #. TRANSLATORS: Button that deletes a reminder
 #: src/app/qml/components/NotebooksDelegate.qml:36
@@ -250,8 +248,7 @@ msgstr ""
 
 #: src/app/qml/components/ResolveConflictConfirmationDialog.qml:38
 msgid "This will <b>delete the changed note on this device</b>."
-msgstr ""
-"Diese Aktion wird <b>die geänderte Notiz von diesem Gerät löschen</b>."
+msgstr "Diese Aktion wird <b>die geänderte Notiz von diesem Gerät löschen</b>."
 
 #: src/app/qml/components/ResolveConflictConfirmationDialog.qml:40
 msgid ""

--- a/po/de.po
+++ b/po/de.po
@@ -166,7 +166,7 @@ msgstr "OK"
 #: src/app/qml/components/EditTagsDialog.qml:202
 #: src/app/qml/ui/EditNoteView.qml:604 src/app/qml/ui/NoteView.qml:150
 msgid "Close"
-msgstr "Schließen"
+msgstr "Fertig"
 
 #. TRANSLATORS: Button that deletes a reminder
 #: src/app/qml/components/NotebooksDelegate.qml:36

--- a/src/app/qml/ui/EditNoteView.qml
+++ b/src/app/qml/ui/EditNoteView.qml
@@ -607,48 +607,6 @@ Item {
             height: units.gu(4)
 
             RtfButton {
-                iconName: "tick"
-                // TRANSLATORS: Button to close the edit mode
-                text: i18n.tr("Close")
-                height: parent.height
-                iconColor: theme.palette.normal.positive
-                onClicked: {
-                    forceActiveFocus();
-                    saveNote();
-                    root.exitEditMode(root.note);
-                }
-            }
-
-            RtfSeparator { }
-
-            RtfButton {
-                iconName: "undo"
-                height: parent.height
-                width: height
-                enabled: formattingHelper.canUndo
-                onClicked: {
-                    formattingHelper.undo();
-                }
-            }
-            RtfButton {
-                iconName: "redo"
-                height: parent.height
-                width: height
-                enabled: formattingHelper.canRedo
-                onClicked: {
-                    formattingHelper.redo();
-                }
-            }
-
-            RtfSeparator {}
-
-            Item {
-                Layout.fillWidth: true
-            }
-
-            RtfSeparator {}
-
-            RtfButton {
                 iconName: "select"
                 height: parent.height
                 width: height
@@ -682,8 +640,6 @@ Item {
                 }
             }
 
-            RtfSeparator {}
-
             RtfButton {
                 iconName: "navigation-menu"
                 height: parent.height
@@ -701,6 +657,44 @@ Item {
                 active: toolbox.charFormatExpanded
                 onClicked: {
                     toolbox.charFormatExpanded = !toolbox.charFormatExpanded
+                }
+            }
+
+            RtfButton {
+                iconName: "undo"
+                height: parent.height
+                width: height
+                enabled: formattingHelper.canUndo
+                onClicked: {
+                    formattingHelper.undo();
+                }
+            }
+            RtfButton {
+                iconName: "redo"
+                height: parent.height
+                width: height
+                enabled: formattingHelper.canRedo
+                onClicked: {
+                    formattingHelper.redo();
+                }
+            }
+
+            Item {
+                Layout.fillWidth: true
+            }
+
+            RtfSeparator {}
+
+            RtfButton {
+                //iconName: "tick"
+                // TRANSLATORS: Button to close the edit mode
+                text: i18n.tr("Close")
+                height: parent.height
+                iconColor: theme.palette.normal.positive
+                onClicked: {
+                    forceActiveFocus();
+                    saveNote();
+                    root.exitEditMode(root.note);
                 }
             }
         }


### PR DESCRIPTION
Issues:
1. On some devices (i.e. BQ E5) in portrait mode one icon is not visible (edit-select-all button).
2. In landscape mode  some icons are on the left, some on the right.

Solution:
1. remove separators to free up some space
2. remove tick icon from close button to free up some space
3. reorder icons to be more intuitive
--
4. Change German translation of Close
--
5. clickable says sdk is no longer an valid option --> removed
--
6. raised version to 0.6.4